### PR TITLE
Fine-Tune BERT for NER Using HuggingFace

### DIFF
--- a/src/files/hf_bert-file-tune.py
+++ b/src/files/hf_bert-file-tune.py
@@ -1,4 +1,4 @@
-from transformers import AutoTokenizer
+from transformers import *
 tokenizer = AutoTokenizer.from_pretrained("bert-base-multilingual-cased")
 
 #Get the values for input_ids, token_type_ids, attention_mask

--- a/src/files/hf_bert-file-tune.py
+++ b/src/files/hf_bert-file-tune.py
@@ -1,0 +1,34 @@
+from transformers import AutoTokenizer
+tokenizer = AutoTokenizer.from_pretrained("bert-base-multilingual-cased")
+
+#Get the values for input_ids, token_type_ids, attention_mask
+def tokenize_adjust_labels(all_samples_per_split):
+  tokenized_samples = tokenizer.batch_encode_plus(all_samples_per_split["tokens"], is_split_into_words=True)
+  #tokenized_samples is not a datasets object so this alone won't work with Trainer API, hence map is used 
+  #so the new keys [input_ids, labels (after adjustment)]
+  #can be added to the datasets dict for each train test validation split
+  total_adjusted_labels = []
+  print(len(tokenized_samples["input_ids"]))
+  for k in range(0, len(tokenized_samples["input_ids"])):
+    prev_wid = -1
+    word_ids_list = tokenized_samples.word_ids(batch_index=k)
+    existing_label_ids = all_samples_per_split["ner_tags"][k]
+    i = -1
+    adjusted_label_ids = []
+   
+    for wid in word_ids_list:
+      if(wid is None):
+        adjusted_label_ids.append(-100)
+      elif(wid!=prev_wid):
+        i = i + 1
+        adjusted_label_ids.append(existing_label_ids[i])
+        prev_wid = wid
+      else:
+        label_name = label_names[existing_label_ids[i]]
+        adjusted_label_ids.append(existing_label_ids[i])
+        
+    total_adjusted_labels.append(adjusted_label_ids)
+  tokenized_samples["labels"] = total_adjusted_labels
+  return tokenized_samples
+
+tokenized_dataset = dataset.map(tokenize_adjust_labels, batched=True)


### PR DESCRIPTION
how to fine-tune a model for NER tasks using the powerful HuggingFace library.

We also saw how to integrate with Weights and Biases, how to share our finished model on HuggingFace model hub, and write a beautiful model card documenting our work.